### PR TITLE
Moving clear() to prevent clearing non-interactive selections

### DIFF
--- a/src/kendo.selectable.js
+++ b/src/kendo.selectable.js
@@ -119,15 +119,15 @@ var __meta__ = { // jshint ignore:line
             }
 
             selected = target.hasClass(SELECTED);
-            if (!multiple || !ctrlKey) {
-                that.clear();
-            }
-
             target = target.add(that.relatedTarget(target));
 
             if (shiftKey) {
                 that.selectRange(that._firstSelectee(), target);
             } else {
+                if (!multiple || !ctrlKey) {
+                    that.clear();
+                }
+
                 if (selected && ctrlKey) {
                     that._unselect(target);
                     that._notify(CHANGE);


### PR DESCRIPTION
Referencing issue 

https://github.com/telerik/kendo-ui-core/issues/2728